### PR TITLE
Corrected logic to remove serviceaccount, now deletes keys and all as…

### DIFF
--- a/install/cleanup.sh
+++ b/install/cleanup.sh
@@ -15,6 +15,23 @@
 # limitations under the License.
 
 # Variables
+removeServiceAccount() {
+  echo "Removing Service Account"
+  KEY=$(gcloud iam service-accounts keys list --iam-account $1 --managed-by user | grep -v KEY | xargs | cut -d " " -f 1)
+  if [ ! -z ${KEY} ]
+  then
+    gcloud iam service-accounts keys delete ${KEY} --iam-account $1 -q || true
+  fi
+
+  gcloud iam service-accounts delete $1 -q || true
+  roles=$(gcloud projects get-iam-policy $PROJECT --flatten="bindings[].members" --format='table(bindings.role)' --filter="bindings.members:$1" | grep -v ROLE)
+  #declare -a roles=(${SVC_ACC_ROLES})
+  for role in "${roles[@]}"
+  do
+    echo "Removing role: ${role} to service account $1"
+    gcloud projects remove-iam-policy-binding ${2} --member "serviceAccount:$1" --role "${role}" --quiet > /dev/null || true
+  done
+}
 
 if [[ $OSTYPE == "linux-gnu" && $CLOUD_SHELL == true ]]; then
     export PROJECT_ID=$(gcloud config get-value project)
@@ -53,33 +70,13 @@ if [[ $OSTYPE == "linux-gnu" && $CLOUD_SHELL == true ]]; then
 
 
     echo "🔑 Deleting Firewall updater service account..."
-    gcloud iam service-accounts delete kops-firewall-updater@${PROJECT_ID}.iam.gserviceaccount.com --quiet
-
-    gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
-    --member serviceAccount:${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com \
-    --role roles/compute.securityAdmin
-
+    removeServiceAccount kops-firewall-updater@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID}
 
     echo "🔑 Deleting GCP cluster Hub service account..."
-    gcloud iam service-accounts delete gcp-connect@${PROJECT_ID}.iam.gserviceaccount.com --quiet
-    SVC_ACCT_NAME="gcp-connect"
-
-    gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
-    --member="serviceAccount:${SVC_ACCT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
-    --role="roles/gkehub.connect"
-
-    gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
-    --member="serviceAccount:${SVC_ACCT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
-    --role="roles/gkehub.connect"
-
+    removeServiceAccount gcp-connect@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID}
 
     echo "🔑 Deleting onprem cluster Hub service account..."
-    gcloud iam service-accounts delete anthos-connect@${PROJECT_ID}.iam.gserviceaccount.com --quiet
-
-    gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
-    --member="serviceAccount:anthos-connect@${PROJECT_ID}.iam.gserviceaccount.com" \
-    --role="roles/gkehub.connect"
-
+    removeServiceAccount anthos-connect@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID}
 
     echo "🗑 Finishing up."
     rm -rf $HOME/.kube/config \

--- a/install/cleanup.sh
+++ b/install/cleanup.sh
@@ -70,13 +70,15 @@ if [[ $OSTYPE == "linux-gnu" && $CLOUD_SHELL == true ]]; then
 
 
     echo "🔑 Deleting Firewall updater service account..."
-    removeServiceAccount kops-firewall-updater@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID}
+    removeServiceAccount kops-firewall-updater@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID} &
 
     echo "🔑 Deleting GCP cluster Hub service account..."
-    removeServiceAccount gcp-connect@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID}
+    removeServiceAccount gcp-connect@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID} &
 
     echo "🔑 Deleting onprem cluster Hub service account..."
-    removeServiceAccount anthos-connect@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID}
+    removeServiceAccount anthos-connect@${PROJECT_ID}.iam.gserviceaccount.com ${PROJECT_ID} &
+
+    wait
 
     echo "🗑 Finishing up."
     rm -rf $HOME/.kube/config \


### PR DESCRIPTION
…sociated roles

Script deletes service account keys, then the service account, then loops through all current policy bindings and deletes them, rather than hardcoding role bindings to delete